### PR TITLE
Fix issue with /static/ image files with '@' characters replacing with '_' with used.

### DIFF
--- a/optimize-course-images.py
+++ b/optimize-course-images.py
@@ -46,6 +46,16 @@ def traverse_image_files(directory_path):
                 logging.info(f"Found image file ({uih.get_image_stats(image_path)}): {image_path}")
 
                 try:
+                    # Ensure that file use their `/policies/assets.json` key name when searching the
+                    # course. Example on disk with '/static/iguana-8084900@5257x3505.jpg' including
+                    # the '@' character is the displayName property in the assets.json file, while
+                    # the key name replaces the '@' to '_' and the named used within the course
+                    # content is 'iguana-8084900_5257x3505.jpg' instead.
+                    file = ujh.find_parent_key(
+                        os.path.join(directory_path, "policies", "assets.json"),
+                        file
+                    )
+
                     found_image_usage_in_course = ufh.search_image_in_files(file, directory_path)
                     if found_image_usage_in_course:
                         # Convert all supported extensions to JPEG type and compress.
@@ -107,6 +117,8 @@ def main():
             # Set up logging for the specific tar file
             log_file = os.path.join(log_path, f"{tar_file_name}.log")
             setup_logger(log_file)
+            logging.info("//////////////////////////////////////////////////////////////")
+            logging.info(f"Starting new image optimization for {tar_file_name}")
 
             # Create a copy of the tar file with the .gz extension removed
             tar_file_copy = os.path.join(tmp_destination, tar_file_name + ".tar")

--- a/utils/json_handlers.py
+++ b/utils/json_handlers.py
@@ -124,3 +124,35 @@ def find_json_file(root_dir, filename):
             if file == filename:
                 return os.path.join(dirpath, file)
     return None
+
+def find_parent_key(json_file_path, target_value):
+    """
+    Finds the parent key of a specific value within a JSON file.
+
+    Args:
+        json_file_path (str): The path to the JSON file.
+        target_value: The value to search for.
+
+    Returns:
+        str: The parent key of the target value, or None if not found.
+    """
+    with open(json_file_path, 'r') as file:
+        data = json.load(file)
+
+    def _recursive_search(data, target_value):
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if value == target_value:
+                    return key
+                elif isinstance(value, (dict, list)):
+                  result = _recursive_search(value, target_value)
+                  if result:
+                    return key
+        elif isinstance(data, list):
+            for item in data:
+                result = _recursive_search(item, target_value)
+                if result:
+                    return result 
+        return None
+
+    return _recursive_search(data, target_value)


### PR DESCRIPTION
When testing the `/static/iguana-8084900@5257x3505.jpg` on disk gets renamed to `/static/iguana-8084900_5257x3505.jpg` when used within the HTML content. It appears the `@` character gets converted over to a `_`. I bet this is because of the URL when trying ot access this image.

For now the logic I have removes this image from the course because it recognizes that it's not used. We'll have to use a search for disk `/static/<filename>` in a lookup for the `/policies/assets.json` file for the `displayName` property, then retrieve the dictionary key associated with that property and use that name when searching the course to see if that image is used or not.
